### PR TITLE
return continuous obs bins with obs col metadata

### DIFF
--- a/cherita/dataset/metadata.py
+++ b/cherita/dataset/metadata.py
@@ -46,7 +46,9 @@ def get_obs_col_metadata(
         obs_metadata.append(
             {
                 "name": col,
-                **parse_dtype[t](obs_df[col], obs_params=obs_params, retbins=retbins),
+                **parse_dtype[t](
+                    obs_df[col], obs_params=obs_params.get(col, {}), retbins=retbins
+                ),
             }
         )
     return obs_metadata

--- a/cherita/dataset/metadata.py
+++ b/cherita/dataset/metadata.py
@@ -36,17 +36,24 @@ def get_obs_col_names(adata_group: zarr.Group):
     return obs_col_names
 
 
-def get_obs_col_metadata(adata_group: zarr.Group):
+def get_obs_col_metadata(
+    adata_group: zarr.Group, obs_params: dict = {}, retbins: bool = True
+):
     obs_df = parse_data(adata_group.obs)
     obs_metadata = []
     for col in obs_df.columns:
         t = re.sub(r"[^a-zA-Z]", "", obs_df[col].dtype.name)
-        obs_metadata.append({"name": col, **parse_dtype[t](obs_df[col])})
+        obs_metadata.append(
+            {
+                "name": col,
+                **parse_dtype[t](obs_df[col], obs_params=obs_params, retbins=retbins),
+            }
+        )
     return obs_metadata
 
 
 def get_obs_bin_data(
-    adata_group: zarr.Group, obs_col: str, thresholds: list, nBins: int
+    adata_group: zarr.Group, obs_col: str, thresholds: list, nBins: int = 5
 ):
     obs_s = parse_data(adata_group.obs[obs_col])
     cat, _ = to_categorical(

--- a/cherita/plotting/dotplot.py
+++ b/cherita/plotting/dotplot.py
@@ -66,7 +66,7 @@ def dotplot(
         columns=[m.name for m in markers],
     )
 
-    df[obs_colname], bins = to_categorical(obs, **obs_col)
+    df[obs_colname], bin_data = to_categorical(obs, **obs_col)
 
     if obs_indices is not None:
         df = df.iloc[obs_indices]
@@ -157,7 +157,7 @@ def dotplot(
             colorbar=dict(title=dict(text="Mean expression in group", side="right")),
         ),
         xaxis=dict(
-            title=obs_colname + (f" ({bins} bins)" if bins else ""),
+            title=obs_colname + (f" ({bin_data['nBins']} bins)" if bin_data else ""),
             showline=True,
             linewidth=1,
             linecolor="black",

--- a/cherita/plotting/heatmap.py
+++ b/cherita/plotting/heatmap.py
@@ -68,7 +68,7 @@ def heatmap(
         columns=[m.name for m in markers],
     )
 
-    df[obs_colname], bins = to_categorical(obs, **obs_col)
+    df[obs_colname], bin_data = to_categorical(obs, **obs_col)
 
     if obs_indices is not None:
         df = df.iloc[obs_indices]
@@ -102,7 +102,8 @@ def heatmap(
     layout.update(
         dict(
             xaxis=dict(
-                title=obs_colname + (f" ({bins} bins)" if bins else ""),
+                title=obs_colname
+                + (f" ({bin_data['nBins']} bins)" if bin_data else ""),
                 tickvals=middle_ticks,
                 ticktext=list(df[obs_colname].cat.categories),
                 minor=dict(tickvals=ticks, ticks="outside", ticklen=5),

--- a/cherita/plotting/matrixplot.py
+++ b/cherita/plotting/matrixplot.py
@@ -55,7 +55,7 @@ def matrixplot(
         columns=[m.name for m in markers],
     )
 
-    df[obs_colname], bins = to_categorical(obs, **obs_col)
+    df[obs_colname], bin_data = to_categorical(obs, **obs_col)
 
     if obs_indices is not None:
         df = df.iloc[obs_indices]
@@ -90,7 +90,8 @@ def matrixplot(
             xaxis_type="category",
             xaxis=dict(title="Markers", tickvals=values_df.columns),
             yaxis=dict(
-                title=obs_colname + (f" ({bins} bins)" if bins else ""),
+                title=obs_colname
+                + (f" ({bin_data['nBins']} bins)" if bin_data else ""),
                 tickvals=values_df.index,
                 scaleanchor="x",
             ),

--- a/cherita/plotting/violin.py
+++ b/cherita/plotting/violin.py
@@ -89,7 +89,7 @@ def groupby_violin(
         columns=[marker.name],
     )
 
-    df[obs_colname], bins = to_categorical(obs, **obs_col)
+    df[obs_colname], bin_data = to_categorical(obs, **obs_col)
 
     if obs_indices is not None:
         df = df.iloc[obs_indices]
@@ -123,7 +123,8 @@ def groupby_violin(
         layout=dict(
             yaxis=dict(title=marker.name),
             xaxis=dict(
-                title=obs_colname + (f" ({bins} bins)" if bins else ""),
+                title=obs_colname
+                + (f" ({bin_data['nBins']} bins)" if bin_data else ""),
             ),
         ),
     )

--- a/cherita/utils/adata_utils.py
+++ b/cherita/utils/adata_utils.py
@@ -182,7 +182,6 @@ def type_category(obs, **kwargs):
         "values": categories,
         "n_values": len(categories),
         "codes": codes,
-        "hasnans": obs.hasnans,
         "value_counts": {
             **value_counts,
             **{str(k): v for k, v in obs.value_counts().to_dict().items()},
@@ -198,7 +197,7 @@ def type_bool(obs, **kwargs):
     return data
 
 
-def type_numeric(obs, obs_params: dict = None, retbins: bool = True, **kwargs):
+def type_numeric(obs, obs_params: dict = {}, retbins: bool = True, **kwargs):
     if retbins:
         cat_data, bins = to_categorical(
             obs, type="continuous", fillna=True, **obs_params, **kwargs

--- a/cherita/utils/adata_utils.py
+++ b/cherita/utils/adata_utils.py
@@ -199,8 +199,9 @@ def type_bool(obs, **kwargs):
 
 def type_numeric(obs, obs_params: dict = {}, retbins: bool = True, **kwargs):
     if retbins:
+        # Set fillna to False to avoid type_category not catching NaN values
         cat_data, bins = to_categorical(
-            obs, type="continuous", fillna=True, **obs_params, **kwargs
+            obs, type="continuous", fillna=False, **obs_params, **kwargs
         )
         cat_obs = {**type_category(pd.Series(cat_data)), "bins": bins}
     else:


### PR DESCRIPTION
# Description

Bin continuous obs by default when requesting obs metadata ("obs/cols" endpoint)
Optional `obsParams` request param can define bins or thresholds to use for specific obs columns

Adds support to fix https://github.com/haniffalab/cherita-react/issues/98

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Checklist

- [ ] All tests pass (eg. `pytest`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
