### PR TITLE
parse bin_data thresholds and binEdges to float

### DIFF
--- a/cherita/utils/adata_utils.py
+++ b/cherita/utils/adata_utils.py
@@ -309,8 +309,8 @@ def categorical(c: pd.Categorical, fillna: bool = True, **kwargs):
 
 def get_bin_data(s: pd.Series, thresholds=None, nBins: int = 5):
     if not thresholds:
-        bin_size = (s.max() - s.min()) / nBins
-        thresholds = [s.min() + bin_size * b for b in range(nBins + 1)]
+        bin_size = float(s.max() - s.min()) / nBins
+        thresholds = [float(s.min()) + bin_size * b for b in range(nBins + 1)]
     else:
         nBins = len(thresholds) - 1
     bin_edges = [[thresholds[i], thresholds[i + 1]] for i in range(len(thresholds) - 1)]


### PR DESCRIPTION
# Description

parse bin_data to python float
to fix errors `TypeError: Object of type float32 is not JSON serializable` from requests to obs/cols

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Checklist

- [ ] All tests pass (eg. `pytest`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
