### PR TITLE
add filter to get_obsm_keys

### DIFF
--- a/cherita/dataset/metadata.py
+++ b/cherita/dataset/metadata.py
@@ -156,9 +156,16 @@ def match_var_names(
     return matched_df
 
 
-def get_obsm_keys(adata_group: zarr.Group):
-    obsm_keys = list(adata_group.obsm.keys())
-    return obsm_keys
+def get_obsm_keys(adata_group: zarr.Group, filter2d: bool = True):
+    if filter2d:
+        # Filter to only obsm keys that can be plotted in 2D
+        return [
+            key
+            for key in adata_group.obsm.keys()
+            if adata_group.obsm[key].ndim == 2 and adata_group.obsm[key].shape[1] > 1
+        ]
+    else:
+        return list(adata_group.obsm.keys())
 
 
 def get_kde_values(data):

--- a/cherita/resources/dataset.py
+++ b/cherita/resources/dataset.py
@@ -176,7 +176,8 @@ class ObsmKeys(Resource):
         json_data = request.get_json()
         try:
             adata_group = open_anndata_zarr(json_data["url"])
-            return jsonify(get_obsm_keys(adata_group))
+            filter2d = json_data.get("filter2d", True)
+            return jsonify(get_obsm_keys(adata_group, filter2d))
         except KeyError as e:
             raise BadRequest("Missing required parameter: {}".format(e))
 


### PR DESCRIPTION
# Description

Filter by default to only obsm keys that can be plotted in 2D (at least 2 dims for coordinates)

Fixes #56

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Checklist

- [ ] All tests pass (eg. `pytest`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
