### PR TITLE
fix errors when obsm is not array

### DIFF
--- a/cherita/dataset/metadata.py
+++ b/cherita/dataset/metadata.py
@@ -189,10 +189,12 @@ def match_var_names(
 def get_obsm_keys(adata_group: zarr.Group, filter2d: bool = True):
     if filter2d:
         # Filter to only obsm keys that can be plotted in 2D
+        # i.e. is a zarr array, has float, int or uint dtype, and has at least 2 dimensions
         return [
             key
             for key in adata_group.obsm.keys()
             if isinstance(adata_group.obsm[key], zarr.Array)
+            and adata_group.obsm[key].dtype.kind in "fiu"
             and adata_group.obsm[key].ndim == 2
             and adata_group.obsm[key].shape[1] > 1
         ]


### PR DESCRIPTION
# Description

check obsm is array in get_obsm_keys when filter2d
fixes errors when any obsm key is group/categorical

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Checklist

- [ ] All tests pass (eg. `pytest`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
