### PR TITLE
remove matrixplot layout autosize=false

### DIFF
--- a/cherita/plotting/matrixplot.py
+++ b/cherita/plotting/matrixplot.py
@@ -84,7 +84,6 @@ def matrixplot(
             coloraxis="coloraxis",
         ),
         layout=dict(
-            autosize=False,
             plot_bgcolor="rgba(0,0,0,0)",
             yaxis_type="category",
             xaxis_type="category",


### PR DESCRIPTION
# Description

Remove autosize=false from matrixplot

Fixes matrixplot with non-responsive layout in frontend

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Checklist

- [ ] All tests pass (eg. `pytest`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
