### PR TITLE
fix: error with pandas StringArray categories

### DIFF
--- a/cherita/resources/dataset.py
+++ b/cherita/resources/dataset.py
@@ -18,7 +18,7 @@ from cherita.dataset.metadata import (
 )
 from cherita.dataset.search import search_obs_values, search_var_names
 from cherita.extensions import cache
-from cherita.resources.errors import BadRequest, ReadZarrError
+from cherita.resources.errors import BadRequest
 from cherita.utils.adata_utils import open_anndata_zarr
 from cherita.utils.caching import make_cache_key
 
@@ -153,7 +153,7 @@ class ObsCols(Resource):
                                 obs_params=obs_params,
                                 retbins=retbins,
                             )
-                        except ReadZarrError as e:
+                        except Exception as e:
                             logging.error(f"Failed to read obs column {col}: {e}")
                             col_metadata = None
 

--- a/cherita/utils/adata_utils.py
+++ b/cherita/utils/adata_utils.py
@@ -179,7 +179,7 @@ def fillna_as_undefined(obs):
 
 def type_category(obs, **kwargs):
     obs, undefined_cat = fillna_as_undefined(obs)
-    categories = [str(i) for i in obs.cat.categories.values.flatten()]
+    categories = [str(i) for i in obs.cat.categories.values.tolist()]
     codes = {str(i): idx for idx, i in enumerate(categories)}
     value_counts = {}
 


### PR DESCRIPTION
# Description

replace `flatten()` with `tolist()` to fix error with pandas StringArray categories
catch all exceptions when getting obs cols metadata to avoid breaking response

Fixes #92

## Type of change

- [x] 🐛 Bug fix (non-breaking change that resolves an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚡ Optimisation (non-breaking improvement to performance or efficiency)
- [ ] 🧩 Documentation (adds or improves documentation)
- [ ] 🧱 Maintenance (refactor, dependency update, CI/CD, etc.)
- [ ] 🔥 Breaking change (fix or feature that causes existing functionality to change)

## Checklist

- [ ] All tests pass (eg. `pytest`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
- [ ] Documentation updated (if required)
