### PR TITLE
fix: catch ValueError exception when trying open_consolidated

### DIFF
--- a/cherita/utils/adata_utils.py
+++ b/cherita/utils/adata_utils.py
@@ -138,7 +138,7 @@ def open_anndata_zarr(url: str):
     else:
         try:
             url, storage_options = get_s3_http_options(o)
-        except:
+        except Exception:
             url, storage_options = url, None
 
     try:


### PR DESCRIPTION
# Description

catch `ValueError` exception when trying `open_consolidated` 
fixes opening datasets with no consolidated metadata with new zarr version

Related to #4 

## Type of change

- [x] 🐛 Bug fix (non-breaking change that resolves an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚡ Optimisation (non-breaking improvement to performance or efficiency)
- [ ] 🧩 Documentation (adds or improves documentation)
- [ ] 🧱 Maintenance (refactor, dependency update, CI/CD, etc.)
- [ ] 🔥 Breaking change (fix or feature that causes existing functionality to change)

## Checklist

- [ ] All tests pass (eg. `pytest`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
- [ ] Documentation updated (if required)
